### PR TITLE
Changed the heading form "Training and Consultancy" to "Sponsors"

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@ While the focus of the group is on QGIS we hope to build links with other groups
           <hr class="featurette-divider">
           <a name="training"></a>
           <div class="featurette">
-            <h2 class="featurette-heading">Training and Consultancy</h2>
+            <h2 class="featurette-heading">Sponsors</h2>
             <p class="lead">There are a growing number of UK companies that offer training, support or consultancy for QGIS. If you want to advertise on this site, then please get in contact.
 <p class="lead"><img src="http://ukqgis.files.wordpress.com/2013/06/astun.jpg" width="300" height="88" align="right" style="margin-left: 40px, margin-bottom:40px" ;/></a></p>
 <p class="lead"><a a title="Astun Technology" href="http://astuntechnology.com/training/">Astun Technology </a>offer a range of training courses on QGIS and other Open-Source software, all of which are well attended by both public and private sectors. The company is very well known in the GIS community and is very proactive in supporting and promoting Open-Source technologies.</p>


### PR DESCRIPTION
Better to call it "Sponsors", as it will cause confusions with others who offer the training and consultancy services for QGIS in the UK.
